### PR TITLE
Change from true to present as this is required in the python module

### DIFF
--- a/manifests/install/python.pp
+++ b/manifests/install/python.pp
@@ -6,9 +6,9 @@ class sentry::install::python
 
   if $sentry::manage_python {
     class { '::python':
-      dev        => true,
-      pip        => true,
-      virtualenv => true,
+      dev        => present,
+      pip        => present,
+      virtualenv => present,
     } -> Package <| provider == 'pip' |>
 
     python::virtualenv { $virtualenv_path:


### PR DESCRIPTION
The python module now requires pip, virtualenv, and dev to be either absent, latest, or present and not a boolean.